### PR TITLE
Update documentation and remove simple warnings

### DIFF
--- a/src/plunk/transactional.gleam
+++ b/src/plunk/transactional.gleam
@@ -76,7 +76,7 @@ pub fn send_transactional_email_decoder() -> Decoder(
 /// import gleam/option.{None}
 /// import gleam/hackney
 /// import plunk
-/// import plunk/transactional.{Single, TransactionalEmail}
+/// import plunk/transactional.{Address, TransactionalEmail}
 ///
 /// fn main() {
 ///   let instance = plunk.new(key: "YOUR_API_KEY")

--- a/test/plunk/contacts_test.gleam
+++ b/test/plunk/contacts_test.gleam
@@ -183,7 +183,7 @@ fn setup_new_contact(
 }
 
 pub fn subscribe_test() {
-  let assert #(key, contact) = setup_new_contact(subscribed: False)
+  let #(key, contact) = setup_new_contact(subscribed: False)
   should.be_false(contact.subscribed)
 
   let raw_resp =
@@ -218,7 +218,7 @@ pub fn subscribe_test() {
 }
 
 pub fn unsubscribe_test() {
-  let assert #(key, contact) = setup_new_contact(subscribed: True)
+  let #(key, contact) = setup_new_contact(subscribed: True)
   should.be_true(contact.subscribed)
 
   let raw_resp =
@@ -253,7 +253,7 @@ pub fn unsubscribe_test() {
 }
 
 pub fn delete_test() {
-  let assert #(key, contact) = setup_new_contact(subscribed: True)
+  let #(key, contact) = setup_new_contact(subscribed: True)
 
   let raw_resp =
     plunk.new(key)


### PR DESCRIPTION
Hello, love the package! Thanks for the great work on it, I am glad to be able to use it. I was playing around with it and just noticed that the documentation for transactional.send must've been created with an older type and that there were a couple warnings that could easily be removed (probably only surfaced in the newer versions of Gleam). Thanks again and hope this PR helps!