### PR TITLE
Replace deprecated concat function

### DIFF
--- a/src/plunk/internal/contacts_def.gleam
+++ b/src/plunk/internal/contacts_def.gleam
@@ -211,7 +211,7 @@ fn email_decoder() -> dynamic.Decoder(Email) {
       }
       a, b, c, d, e, f, g, h, i, j, k -> {
         Error(
-          list.concat([
+          list.flatten([
             all_errors(a),
             all_errors(b),
             all_errors(c),


### PR DESCRIPTION
Just a small warning I noticed being emitted when compiling with gleam_stdlib ~0.41. Thanks again for the package!